### PR TITLE
refactor (#31) : 비밀번호 정규식 추가

### DIFF
--- a/src/domain/user/presentation/dto/request/SignupRequest.ts
+++ b/src/domain/user/presentation/dto/request/SignupRequest.ts
@@ -3,6 +3,7 @@ import {
   IsEmail,
   IsNotEmpty,
   IsString,
+  Matches,
   MaxLength,
   MinLength,
 } from 'class-validator';
@@ -20,15 +21,31 @@ export class SignupRequest {
   @IsNotEmpty()
   email: string;
 
-  @ApiProperty({ description: '비밀번호', example: 'P@ssw0rd!' })
+  @ApiProperty({
+    description: '비밀번호 (8~30자, 영문, 숫자, 특수문자 포함)',
+    example: 'P@ssw0rd!',
+  })
   @IsString()
   @IsNotEmpty()
   @MinLength(8)
+  @MaxLength(30)
+  @Matches(/^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*#?&])[A-Za-z\d@$!%*#?&]{8,30}$/, {
+    message:
+      '비밀번호는 8~30자의 영문, 숫자, 특수문자(@$!%*#?&)를 모두 포함해야 합니다.',
+  })
   password: string;
 
-  @ApiProperty({ description: '비밀번호 확인', example: 'P@ssw0rd!' })
+  @ApiProperty({
+    description: '비밀번호 확인 (8~30자, 영문, 숫자, 특수문자 포함)',
+    example: 'P@ssw0rd!',
+  })
   @IsString()
   @IsNotEmpty()
   @MinLength(8)
+  @MaxLength(30)
+  @Matches(/^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*#?&])[A-Za-z\d@$!%*#?&]{8,30}$/, {
+    message:
+      '비밀번호는 8~30자의 영문, 숫자, 특수문자(@$!%*#?&)를 모두 포함해야 합니다.',
+  })
   passwordConfirm: string;
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 비밀번호 유효성 검사 규칙이 강화되었습니다. 비밀번호는 8~30자이며, 영문, 숫자, 특수문자(@$!%*#?&)를 모두 포함해야 합니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->