### PR TITLE
Feature/51 be 메인페이지 api 수정

### DIFF
--- a/src/domain/user/presentation/UserController.ts
+++ b/src/domain/user/presentation/UserController.ts
@@ -48,6 +48,7 @@ export class UserController {
   }
   
   @Get("mainpage/me")
+  @UserApiBearerAuth()
   @ApiOperation({ summary: '메인페이지 유저 정보'})
   @ApiResponse({
     status: 200,

--- a/src/domain/user/presentation/dto/response/MainPageResponse.ts
+++ b/src/domain/user/presentation/dto/response/MainPageResponse.ts
@@ -16,7 +16,7 @@ export class MainpageResponse{
   @ApiProperty({ description: '프로필 이미지', example: 'https://cdn.mohaeng.com/profiles/.jpg'})
   profileImage: string | null;
 
-  @ApiProperty({ description: '방문 국가 수', example: '12'})
+  @ApiProperty({ description: '방문 국가 수', example: 12 })
   visitedCountries: number;
 
   static fromEntity(user: {

--- a/src/domain/user/service/UserService.ts
+++ b/src/domain/user/service/UserService.ts
@@ -86,7 +86,7 @@ export class UserService {
     if(!user){
       throw new UserNotFoundException();
     }
-    return user;
+    return MainpageResponse.fromEntity(user);
   }
 
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 사용자 메인페이지 정보를 반환하는 새 API 엔드포인트가 추가되었습니다 (/v1/users/mainpage/me).
  * 메인페이지 전용 응답 형식(MainpageResponse)을 도입 — id, 이름, 이메일, 프로필 이미지(또는 null), 방문 국가 수 포함.
  * 사용자 조회 서비스가 추가되어 ID로 사용자 조회 후 일관된 메인페이지 응답을 반환하고, 존재하지 않을 경우 예외 처리합니다.
  * API 문서에 해당 엔드포인트와 응답이 반영되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->