### PR TITLE
fix (#0) : PostgreSQL date 타입 string 반환 시 formatDate 에러 방지

### DIFF
--- a/src/domain/itinerary/presentation/dto/response/ItineraryResultResponse.ts
+++ b/src/domain/itinerary/presentation/dto/response/ItineraryResultResponse.ts
@@ -202,7 +202,11 @@ export class ItineraryResultResponse {
       }));
   }
 
-  private static formatDate(date: Date): string {
+  private static formatDate(date: Date | string): string {
+    // PostgreSQL date 타입은 TypeORM이 string으로 반환하므로 양쪽 모두 처리
+    if (typeof date === 'string') {
+      return date.slice(0, 10); // "2024-01-15T00:00:00.000Z" → "2024-01-15"
+    }
     const year = date.getFullYear();
     const month = String(date.getMonth() + 1).padStart(2, '0');
     const day = String(date.getDate()).padStart(2, '0');

--- a/src/domain/itinerary/processor/ItineraryModificationProcessor.ts
+++ b/src/domain/itinerary/processor/ItineraryModificationProcessor.ts
@@ -202,11 +202,13 @@ export class ItineraryModificationProcessor extends WorkerHost {
   /**
    * Date → YYYY-MM-DD 문자열 변환
    */
-  private formatDate(date: Date): string {
-    const d = new Date(date);
-    const year = d.getFullYear();
-    const month = String(d.getMonth() + 1).padStart(2, '0');
-    const day = String(d.getDate()).padStart(2, '0');
+  private formatDate(date: Date | string): string {
+    if (typeof date === 'string') {
+      return date.slice(0, 10);
+    }
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const day = String(date.getDate()).padStart(2, '0');
     return `${year}-${month}-${day}`;
   }
 }

--- a/src/domain/itinerary/processor/ItineraryProcessor.ts
+++ b/src/domain/itinerary/processor/ItineraryProcessor.ts
@@ -162,7 +162,10 @@ export class ItineraryProcessor extends WorkerHost {
   /**
    * Date → YYYY-MM-DD 문자열 변환
    */
-  private formatDate(date: Date): string {
+  private formatDate(date: Date | string): string {
+    if (typeof date === 'string') {
+      return date.slice(0, 10);
+    }
     const year = date.getFullYear();
     const month = String(date.getMonth() + 1).padStart(2, '0');
     const day = String(date.getDate()).padStart(2, '0');


### PR DESCRIPTION
- TypeORM + PostgreSQL 환경에서 date 컬럼이 Date 객체가 아닌 string으로 반환되어 getFullYear() 호출 시 TypeError 발생
- ItineraryResultResponse, ItineraryProcessor, ItineraryModificationProcessor 세 곳 동일 패턴 수정
- string이면 slice(0,10)으로 YYYY-MM-DD 반환, Date면 기존 로직 유지