### PR TITLE
feat (#166) : 탈퇴 계정 복구 기능 추가

### DIFF
--- a/src/domain/auth/presentation/AuthController.ts
+++ b/src/domain/auth/presentation/AuthController.ts
@@ -23,6 +23,7 @@ import { AuthTokensResponse } from './dto/response/AuthTokensResponse';
 import { CurrentUserResponse } from './dto/response/CurrentUserResponse';
 import { SendEmailOtpRequest } from './dto/request/SendEmailOtpRequest';
 import { VerifyEmailOtpRequest } from './dto/request/VerifyEmailOtpRequest';
+import { ReactivateRequest } from './dto/request/ReactivateRequest';
 import { SendEmailOtpResponse } from './dto/response/SendEmailOtpResponse';
 import { VerifyEmailOtpResponse } from './dto/response/VerifyEmailOtpResponse';
 import { GoogleAuthGuard } from '../guard/google-auth.guard';
@@ -67,8 +68,7 @@ export class AuthController {
   async sendEmailOtp(
     @Body() request: SendEmailOtpRequest,
   ): Promise<SendEmailOtpResponse> {
-    const sent = await this.authService.sendEmailOtp(request.email);
-    return { sent };
+    return await this.authService.sendEmailOtp(request.email);
   }
 
   @Post('email/otp/verify')
@@ -88,6 +88,29 @@ export class AuthController {
       request.otp,
     );
     return { verified };
+  }
+
+  @Post('reactivate')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: '탈퇴 계정 복구',
+    description:
+      '비활성화된 계정을 복구합니다. 이메일 OTP 인증 완료 후 호출해야 합니다.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: '계정 복구 성공, 토큰 발급',
+    type: AuthTokensResponse,
+  })
+  @ApiResponse({ status: 400, description: '이메일 인증이 완료되지 않았거나 유효하지 않은 요청' })
+  async reactivate(
+    @Body() request: ReactivateRequest,
+  ): Promise<AuthTokensResponse> {
+    const tokens = await this.authService.reactivate(request.email);
+    return {
+      accessToken: tokens.accessToken,
+      refreshToken: tokens.refreshToken,
+    };
   }
 
   @Post('refresh')

--- a/src/domain/auth/presentation/dto/request/ReactivateRequest.ts
+++ b/src/domain/auth/presentation/dto/request/ReactivateRequest.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEmail, IsNotEmpty } from 'class-validator';
+
+export class ReactivateRequest {
+  @ApiProperty({ description: '복구할 계정 이메일', example: 'user@example.com' })
+  @IsEmail()
+  @IsNotEmpty()
+  email: string;
+}

--- a/src/domain/auth/presentation/dto/response/SendEmailOtpResponse.ts
+++ b/src/domain/auth/presentation/dto/response/SendEmailOtpResponse.ts
@@ -3,4 +3,7 @@ import { ApiProperty } from '@nestjs/swagger';
 export class SendEmailOtpResponse {
   @ApiProperty({ description: 'otp send result' })
   sent: boolean;
+
+  @ApiProperty({ description: '계정 활성화 여부 (false면 계정 복구 흐름으로 안내)' })
+  isActivate: boolean;
 }

--- a/src/domain/auth/service/AuthService.ts
+++ b/src/domain/auth/service/AuthService.ts
@@ -18,6 +18,7 @@ import { AuthEmailOtpCooldownException } from '../exception/AuthEmailOtpCooldown
 import { AuthEmailOtpTooManyRequestsException } from '../exception/AuthEmailOtpTooManyRequestsException';
 import { AuthInvalidEmailOtpException } from '../exception/AuthInvalidEmailOtpException';
 import { AuthEmailOtpMaxAttemptsExceededException } from '../exception/AuthEmailOtpMaxAttemptsExceededException';
+import { AuthEmailNotVerifiedException } from '../exception/AuthEmailNotVerifiedException';
 import { LoginRequest } from '../presentation/dto/request/LoginRequest';
 import { OAuthCodeRepository } from '../persistence/OAuthCodeRepository';
 import { GlobalJwtService } from '../../../global/jwt/GlobalJwtService';
@@ -84,14 +85,17 @@ export class AuthService {
     return this.issueTokens(user);
   }
 
-  async sendEmailOtp(email: string): Promise<boolean> {
+  async sendEmailOtp(
+    email: string,
+  ): Promise<{ sent: boolean; isActivate: boolean }> {
     const normalizedEmail = this.normalizeEmail(email);
 
-    // 이메일 중복 확인 (이미 가입된 이메일은 OTP 발송 차단)
+    // 이메일 중복 확인 (활성 계정은 OTP 발송 차단, 비활성 계정은 복구 흐름으로 허용)
     const existingUser = await this.userRepository.findByEmail(normalizedEmail);
-    if (existingUser) {
+    if (existingUser && existingUser.isActivate) {
       throw new EmailAlreadyExistsException();
     }
+    const isActivate = !(existingUser && !existingUser.isActivate);
 
     const otpKey = this.getOtpKey(normalizedEmail);
     const cooldownKey = this.getOtpCooldownKey(normalizedEmail);
@@ -136,7 +140,7 @@ export class AuthService {
       );
     }
 
-    return true;
+    return { sent: true, isActivate };
   }
 
   async verifyEmailOtp(email: string, otp: string): Promise<boolean> {
@@ -235,6 +239,35 @@ export class AuthService {
 
     // 5. 같은 jti로 새 토큰 발급 (같은 디바이스 슬롯 유지, LRU 구현)
     return this.issueTokens(user, jti);
+  }
+
+  async reactivate(email: string): Promise<AuthTokens> {
+    const normalizedEmail = this.normalizeEmail(email);
+
+    // OTP 인증 완료 확인
+    const verifiedKey = this.getOtpVerifiedKey(normalizedEmail);
+    const isVerified = await this.redisService.get(verifiedKey);
+    if (!isVerified) {
+      throw new AuthEmailNotVerifiedException();
+    }
+
+    // 비활성 유저 조회
+    const user = await this.userRepository.findByEmail(normalizedEmail);
+    if (!user) {
+      throw new UserNotFoundException();
+    }
+    if (user.isActivate) {
+      throw new EmailAlreadyExistsException();
+    }
+
+    // 계정 활성화
+    await this.userRepository.reactivate(user.id);
+    user.isActivate = true;
+
+    // 인증 완료 플래그 삭제 (일회용)
+    await this.redisService.delete(verifiedKey);
+
+    return this.issueTokens(user);
   }
 
   async issueTokens(user: User, existingJti?: string): Promise<AuthTokens> {

--- a/src/domain/user/persistence/UserRepository.ts
+++ b/src/domain/user/persistence/UserRepository.ts
@@ -82,6 +82,15 @@ export class UserRepository {
   }
 
   /**
+   * 사용자 계정 활성화 (소프트 삭제 복구)
+   * @param id - 사용자 ID
+   * @returns Promise<void>
+   */
+  async reactivate(id: string): Promise<void> {
+    await this.repository.update(id, { isActivate: true });
+  }
+
+  /**
    * 사용자 영구 삭제
    * @param id - 사용자 ID
    * @returns Promise<void>


### PR DESCRIPTION
- OTP 발송 시 비활성 계정 여부(isActivate) 응답 필드 추가
- POST /v1/auth/reactivate 엔드포인트 추가 (OTP 인증 후 계정 복구 및 토큰 발급)
- UserRepository에 reactivate() 메서드 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* 계정 복구 기능 추가 - 비활성화된 계정을 이메일 인증으로 다시 활성화할 수 있습니다.

## Improvements
* 이메일 OTP 발송 로직 개선 - 비활성화된 사용자도 인증 이메일을 수신하여 계정 복구 프로세스를 진행할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->