### PR TITLE
feat (#186) : 메인페이지 로드맵 조회 API 정렬 기준 추가 (최신순/인기순)

### DIFF
--- a/src/domain/course/persistence/TravelCourseRepository.ts
+++ b/src/domain/course/persistence/TravelCourseRepository.ts
@@ -92,14 +92,15 @@ export class TravelCourseRepository {
   }
 
   /**
-   * 메인페이지용 인기 코스 조회
+   * 메인페이지용 코스 조회
    * @description
    * - 공개 코스만 조회
-   * - 좋아요순 정렬
+   * - latest: 최신순 (createdAt DESC), popular: 인기순 (likeCount DESC)
    * - 국가 필터링 옵션 (ISO 3166-1 alpha-2 코드)
    * - 최대 10개까지 조회
    */
-  async findPopularCoursesForMainPage(
+  async findCoursesForMainPage(
+    sortBy: 'latest' | 'popular' = 'latest',
     countryCode?: string,
     page: number = 1,
     limit: number = 10,
@@ -119,10 +120,13 @@ export class TravelCourseRepository {
 
     // Postgres + pagination + getManyAndCount 조합에서 발생하는 별칭 오류를 피하기 위해
     // ID 목록은 raw 쿼리로 분리 조회한다.
+    const orderColumn =
+      sortBy === 'popular' ? 'course.likeCount' : 'course.createdAt';
+
     const pagedIds = await baseQuery
       .clone()
       .select('course.id', 'id')
-      .orderBy('course.likeCount', 'DESC')
+      .orderBy(orderColumn, 'DESC')
       .skip((page - 1) * limit)
       .take(limit)
       .getRawMany<{ id: string }>();
@@ -134,6 +138,9 @@ export class TravelCourseRepository {
     }
 
     // 2단계: ID 기반으로 relation 별도 로딩
+    const orderField: keyof TravelCourse =
+      sortBy === 'popular' ? 'likeCount' : 'createdAt';
+
     const courses = await this.repository.find({
       where: courseIds.map((id) => ({ id })),
       relations: [
@@ -146,7 +153,7 @@ export class TravelCourseRepository {
         'hashTags',
       ],
       relationLoadStrategy: 'query',
-      order: { likeCount: 'DESC' },
+      order: { [orderField]: 'DESC' },
     });
 
     return [courses, total];

--- a/src/domain/course/presentation/TravelCourseController.ts
+++ b/src/domain/course/presentation/TravelCourseController.ts
@@ -20,7 +20,7 @@ import { UserId } from '../../../global/decorators/UserId';
 import { TravelCourseService } from '../service/TravelCourseService';
 import { CourseLikeService } from '../service/CourseLikeService';
 import { GetMyCoursesRequest } from './dto/request/GetMyCoursesRequest';
-import { GetCoursesRequest } from './dto/request/GetCoursesRequest';
+import { GetCoursesRequest, CourseSortType } from './dto/request/GetCoursesRequest';
 import { CourseResponse } from './dto/response/CourseResponse';
 import { CoursesResponse } from './dto/response/CoursesResponse';
 import { CourseLikesResponse } from './dto/response/CourseLikesResponse';
@@ -44,6 +44,7 @@ export class TravelCourseController {
    */
   @Get('mainpage')
   @ApiOperation({ summary: '여행 코스 목록 조회 (메인페이지)' })
+  @ApiQuery({ name: 'sortBy', required: false, enum: CourseSortType, example: CourseSortType.LATEST })
   @ApiQuery({ name: 'countryCode', required: false, example: 'JP' })
   @ApiQuery({ name: 'page', required: false, example: 1 })
   @ApiQuery({ name: 'limit', required: false, example: 10 })
@@ -53,6 +54,7 @@ export class TravelCourseController {
     @Query() request: GetCoursesRequest,
   ): Promise<CoursesResponse> {
     return this.travelCourseService.getCoursesForMainPage(
+      request.sortBy,
       request.countryCode,
       request.page,
       request.limit,

--- a/src/domain/course/presentation/dto/request/GetCoursesRequest.ts
+++ b/src/domain/course/presentation/dto/request/GetCoursesRequest.ts
@@ -1,14 +1,34 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsOptional, IsString, IsInt, Min, Max } from 'class-validator';
+import { IsOptional, IsString, IsInt, Min, Max, IsEnum } from 'class-validator';
 import { Type } from 'class-transformer';
+
+/**
+ * CourseSortType Enum
+ * @description
+ * - 여행 코스 정렬 기준
+ */
+export enum CourseSortType {
+  LATEST = 'latest',
+  POPULAR = 'popular',
+}
 
 /**
  * GetCoursesRequest DTO
  * @description
  * - 여행 코스 목록 조회 요청 (메인페이지)
- * - 국가별 필터링 및 하트순(좋아요순) 정렬
+ * - 국가별 필터링 및 정렬 기준 선택 가능
  */
 export class GetCoursesRequest {
+  @ApiProperty({
+    description: '정렬 기준 (latest: 최신순, popular: 인기순)',
+    enum: CourseSortType,
+    default: CourseSortType.LATEST,
+    required: false,
+  })
+  @IsOptional()
+  @IsEnum(CourseSortType)
+  sortBy?: CourseSortType = CourseSortType.LATEST;
+
   @ApiProperty({
     description: '국가 코드 (ISO 3166-1 alpha-2, 필터링용)',
     required: false,

--- a/src/domain/course/service/TravelCourseService.ts
+++ b/src/domain/course/service/TravelCourseService.ts
@@ -218,16 +218,18 @@ export class TravelCourseService {
   }
 
   /**
-   * 메인페이지용 인기 코스 조회
+   * 메인페이지용 코스 조회
    */
   async getCoursesForMainPage(
+    sortBy: 'latest' | 'popular' = 'latest',
     countryCode?: string,
     page: number = 1,
     limit: number = 10,
     userId?: string,
   ): Promise<CoursesResponse> {
     const [courses, total] =
-      await this.travelCourseRepository.findPopularCoursesForMainPage(
+      await this.travelCourseRepository.findCoursesForMainPage(
+        sortBy,
         countryCode,
         page,
         limit,


### PR DESCRIPTION
## 개요

closes #186

메인페이지 여행 코스(로드맵) 조회 API에 정렬 기준(`sortBy`) 파라미터를 추가합니다.

블로그 조회 API는 이미 `latest`/`popular` 정렬을 지원하고 있었으나, 코스 조회 API는 항상 인기순(좋아요순)으로만 고정되어 있었습니다.

## 변경 사항

- `GetCoursesRequest` DTO에 `CourseSortType` enum 및 `sortBy` 필드 추가 (기본값: `latest`)
- `TravelCourseRepository.findCoursesForMainPage` — `sortBy` 파라미터 추가
  - `latest`: `createdAt DESC` (최신순)
  - `popular`: `likeCount DESC` (인기순)
- `TravelCourseService.getCoursesForMainPage` — `sortBy` 파라미터 추가 및 레포지토리에 전달
- `TravelCourseController` — `sortBy` 쿼리 파라미터 전달 및 Swagger 문서 반영

## API

```
GET /api/v1/courses/mainpage?sortBy=latest   # 최신순
GET /api/v1/courses/mainpage?sortBy=popular  # 인기순 (좋아요순)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 메인 페이지에서 여행 코스를 정렬하는 기능이 추가되었습니다. 사용자는 이제 최신순 또는 인기순으로 코스를 정렬할 수 있습니다.
  * API 쿼리 매개변수를 통해 정렬 옵션을 선택할 수 있습니다(기본값: 최신순).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->