### PR TITLE
fix (#189) : travel_course.modification_count 누락 Postgres 마이그레이션 추가

### DIFF
--- a/src/database/migrations/postgres/1772600000000-AddModificationCountToTravelCoursePostgres.ts
+++ b/src/database/migrations/postgres/1772600000000-AddModificationCountToTravelCoursePostgres.ts
@@ -1,0 +1,69 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * AddModificationCountToTravelCoursePostgres
+ * @description
+ * - PR #181에서 MySQL 마이그레이션은 작성되었으나 Postgres 마이그레이션이 누락됨
+ * - travel_course.modification_count 컬럼 추가 (AI 자연어 수정 요청 횟수, 최대 5회)
+ * - 컬럼이 이미 존재하는 경우 skip (idempotent)
+ */
+export class AddModificationCountToTravelCoursePostgres1772600000000
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    if (queryRunner.connection.options.type !== 'postgres') {
+      return;
+    }
+
+    const hasColumn = await this.columnExists(
+      queryRunner,
+      'travel_course',
+      'modification_count',
+    );
+
+    if (!hasColumn) {
+      await queryRunner.query(`
+        ALTER TABLE "travel_course"
+        ADD COLUMN "modification_count" integer NOT NULL DEFAULT 0
+      `);
+    }
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    if (queryRunner.connection.options.type !== 'postgres') {
+      return;
+    }
+
+    const hasColumn = await this.columnExists(
+      queryRunner,
+      'travel_course',
+      'modification_count',
+    );
+
+    if (hasColumn) {
+      await queryRunner.query(`
+        ALTER TABLE "travel_course"
+        DROP COLUMN "modification_count"
+      `);
+    }
+  }
+
+  private async columnExists(
+    queryRunner: QueryRunner,
+    tableName: string,
+    columnName: string,
+  ): Promise<boolean> {
+    const rows = await queryRunner.query(
+      `
+      SELECT 1
+      FROM information_schema.columns
+      WHERE table_schema = 'public'
+        AND table_name = $1
+        AND column_name = $2
+      LIMIT 1
+      `,
+      [tableName, columnName],
+    );
+    return rows.length > 0;
+  }
+}


### PR DESCRIPTION
## 관련 이슈
closes #189

## 원인
PR #181에서 `modification_count` 컬럼을 `TravelCourse` 엔티티에 추가하고 MySQL 마이그레이션은 작성되었으나, **Postgres 마이그레이션이 누락**되어 프로덕션 DB에 컬럼이 존재하지 않음.

## 해결
`src/database/migrations/postgres/1772600000000-AddModificationCountToTravelCoursePostgres.ts` 추가
- `travel_course` 테이블에 `modification_count INTEGER NOT NULL DEFAULT 0` 컬럼 추가
- 컬럼이 이미 존재하는 경우 skip (idempotent)
- Postgres 전용 가드(`connection.options.type !== 'postgres'`) 적용


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **데이터베이스 업데이트**
  * 데이터베이스 스키마가 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->