### PR TITLE
feat (#192) : 서버 부트스트랩 시 Discord 웹훅 init 알림 추가

### DIFF
--- a/src/global/logger/DiscordService.ts
+++ b/src/global/logger/DiscordService.ts
@@ -44,10 +44,17 @@ export class DiscordService {
   }
 
   /**
+   * Discord로 정보 로그 전송 (서버 시작 등)
+   */
+  async sendInfo(message: string, context?: string): Promise<void> {
+    await this.sendLog('INFO', message, context);
+  }
+
+  /**
    * Discord 웹훅으로 로그 전송
    */
   private async sendLog(
-    level: 'ERROR' | 'WARN',
+    level: 'ERROR' | 'WARN' | 'INFO',
     message: string,
     context?: string,
     stack?: string,
@@ -71,7 +78,7 @@ export class DiscordService {
    * Discord Embed 객체 생성
    */
   private createEmbed(
-    level: 'ERROR' | 'WARN',
+    level: 'ERROR' | 'WARN' | 'INFO',
     message: string,
     context?: string,
     stack?: string,
@@ -124,7 +131,7 @@ export class DiscordService {
   /**
    * 로그 레벨별 설정 반환
    */
-  private getLogConfig(level: 'ERROR' | 'WARN') {
+  private getLogConfig(level: 'ERROR' | 'WARN' | 'INFO') {
     const configs = {
       ERROR: {
         emoji: '🚨',
@@ -133,6 +140,10 @@ export class DiscordService {
       WARN: {
         emoji: '⚠️',
         color: 16776960,
+      },
+      INFO: {
+        emoji: '💡',
+        color: 3447003,
       },
     };
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,7 @@ import * as cookieParser from 'cookie-parser';
 import { AppModule } from './app.module';
 import { GlobalExceptionFilter } from './global/filters/GlobalExceptionFilter';
 import { ResponseInterceptor } from './global/interceptors/ResponseInterceptor';
+import { DiscordService } from './global/logger/DiscordService';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
@@ -61,6 +62,9 @@ async function bootstrap() {
   const port = process.env.PORT ?? 8080;
   await app.listen(port);
   console.log(`Server started on port: ${port}`);
+
+  const discordService = app.get(DiscordService);
+  await discordService.sendInfo('Mohaeng Core SERVER INIT OK', 'Bootstrap');
 }
 
 bootstrap().catch((error) => {


### PR DESCRIPTION
## 관련 이슈
closes #192

## 변경 사항

### `DiscordService`
- `sendInfo(message, context)` 메서드 추가 (INFO 레벨, 💡 파란색 `#3447003`)
- `sendLog` / `createEmbed` / `getLogConfig` 의 level 타입에 `'INFO'` 추가

### `main.ts`
- `app.listen()` 완료 후 DI 컨테이너에서 `DiscordService` 주입받아 `sendInfo` 호출

## 알림 형식

```
💡 INFO - Mohaeng Core
Mohaeng Core SERVER INIT OK
Context: Bootstrap
Time: AM 11:10:14
Server: Mohaeng Core (production)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 출시 노트

* **새로운 기능**
  * 정보성 로그 레벨 추가로 오류 및 경고 외의 일반 정보성 메시지 기록 가능
  * 서버 시작 시 초기화 완료 알림 전송

<!-- end of auto-generated comment: release notes by coderabbit.ai -->