### PR TITLE
fix: 로드맵 수정 콜백 422 검증 처리 개선

### DIFF
--- a/src/domain/itinerary/presentation/dto/request/ItineraryModificationCallbackRequest.spec.ts
+++ b/src/domain/itinerary/presentation/dto/request/ItineraryModificationCallbackRequest.spec.ts
@@ -1,0 +1,67 @@
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { ItineraryModificationCallbackRequest } from './ItineraryModificationCallbackRequest';
+import { flattenValidationErrors } from '../../../../../global/validation/flattenValidationErrors';
+
+describe('ItineraryModificationCallbackRequest', () => {
+  it('accepts ASK_CLARIFICATION without diff_keys', async () => {
+    const payload = plainToInstance(ItineraryModificationCallbackRequest, {
+      status: 'ASK_CLARIFICATION',
+      message: '어떤 장소를 삭제할까요?',
+    });
+
+    const errors = await validate(payload, {
+      whitelist: true,
+      forbidNonWhitelisted: true,
+    });
+
+    expect(errors).toHaveLength(0);
+  });
+
+  it('keeps SUCCESS strict for modified_itinerary shape', async () => {
+    const payload = plainToInstance(ItineraryModificationCallbackRequest, {
+      status: 'SUCCESS',
+      message: '요청한 일정으로 변경했어요.',
+      diff_keys: ['day1_place2'],
+      modified_itinerary: {
+        start_date: '2026-02-11',
+        end_date: '2026-02-11',
+        trip_days: 1,
+        nights: 0,
+        people_count: 2,
+        tags: ['도심'],
+        title: '서울 당일치기',
+        summary: '요약',
+        itinerary: [
+          {
+            day_number: 1,
+            daily_date: '2026-02-11',
+            places: [
+              {
+                place_name: '국립현대미술관 서울관',
+                place_id: 'place_id_2',
+                address: '서울 종로구 삼청로 30',
+                latitude: 37.5787,
+                longitude: 126.9809,
+                place_url: 'https://maps.google.com/?q=mmca',
+                description: '도심에서 예술 전시를 즐길 수 있는 공간입니다.',
+                visit_sequence: 2,
+                visit_time: '11:00',
+                duration_minutes: 90,
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    const errors = await validate(payload, {
+      whitelist: true,
+      forbidNonWhitelisted: true,
+    });
+
+    expect(flattenValidationErrors(errors)).toContain(
+      'modified_itinerary.itinerary.0.places.0.duration_minutes: property duration_minutes should not exist',
+    );
+  });
+});

--- a/src/domain/itinerary/presentation/dto/request/ItineraryModificationCallbackRequest.ts
+++ b/src/domain/itinerary/presentation/dto/request/ItineraryModificationCallbackRequest.ts
@@ -117,6 +117,15 @@ class ModifiedItineraryRequest {
   itinerary: CallbackDayRequest[];
 }
 
+type ModificationCallbackCondition = {
+  status?:
+    | 'SUCCESS'
+    | 'ASK_CLARIFICATION'
+    | 'GENERAL_CHAT'
+    | 'REJECTED'
+    | 'FAILED';
+};
+
 /**
  * ItineraryModificationCallbackRequest
  * @description Python LLM 서버로부터의 수정 콜백 요청 DTO
@@ -145,7 +154,9 @@ export class ItineraryModificationCallbackRequest {
     required: true,
     type: ModifiedItineraryRequest,
   })
-  @ValidateIf((o) => o.status === 'SUCCESS')
+  @ValidateIf(
+    (payload: ModificationCallbackCondition) => payload.status === 'SUCCESS',
+  )
   @IsDefined()
   @ValidateNested()
   @Type(() => ModifiedItineraryRequest)
@@ -163,16 +174,18 @@ export class ItineraryModificationCallbackRequest {
     description: 'AI 응답 메시지 (status가 FAILED가 아닐 때)',
     example: '1일차 2번째 장소를 도쿄 국립 박물관으로 변경했습니다.',
   })
-  @ValidateIf((o) => o.status !== 'FAILED')
+  @ValidateIf(
+    (payload: ModificationCallbackCondition) => payload.status !== 'FAILED',
+  )
   @IsString()
   message?: string;
 
-  @ApiProperty({
-    description: '변경된 노드 ID 목록 (status가 FAILED가 아닐 때)',
+  @ApiPropertyOptional({
+    description:
+      '변경된 노드 ID 목록 (있을 때만 전달, 미전달 시 변경 추적 없음으로 처리)',
     type: [String],
-    required: true,
   })
-  @ValidateIf((o) => o.status !== 'FAILED')
+  @IsOptional()
   @IsArray()
   @IsString({ each: true })
   diff_keys?: string[];
@@ -182,7 +195,9 @@ export class ItineraryModificationCallbackRequest {
     required: false,
     type: CallbackErrorRequest,
   })
-  @ValidateIf((o) => o.status === 'FAILED')
+  @ValidateIf(
+    (payload: ModificationCallbackCondition) => payload.status === 'FAILED',
+  )
   @IsDefined()
   @ValidateNested()
   @Type(() => CallbackErrorRequest)

--- a/src/global/validation/flattenValidationErrors.ts
+++ b/src/global/validation/flattenValidationErrors.ts
@@ -1,0 +1,29 @@
+import { ValidationError } from '@nestjs/common';
+
+export function flattenValidationErrors(errors: ValidationError[]): string[] {
+  const messages: string[] = [];
+
+  const collect = (error: ValidationError, parentPath?: string) => {
+    const currentPath = parentPath
+      ? `${parentPath}.${error.property}`
+      : error.property;
+
+    if (error.constraints) {
+      for (const constraint of Object.values(error.constraints)) {
+        messages.push(
+          currentPath ? `${currentPath}: ${constraint}` : constraint,
+        );
+      }
+    }
+
+    for (const child of error.children ?? []) {
+      collect(child, currentPath);
+    }
+  };
+
+  for (const error of errors) {
+    collect(error);
+  }
+
+  return messages.length > 0 ? messages : ['Validation failed'];
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,6 +10,7 @@ import { AppModule } from './app.module';
 import { GlobalExceptionFilter } from './global/filters/GlobalExceptionFilter';
 import { ResponseInterceptor } from './global/interceptors/ResponseInterceptor';
 import { DiscordService } from './global/logger/DiscordService';
+import { flattenValidationErrors } from './global/validation/flattenValidationErrors';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
@@ -29,9 +30,7 @@ async function bootstrap() {
       forbidNonWhitelisted: true,
       transform: true,
       exceptionFactory: (errors: ValidationError[]) => {
-        const messages = errors.flatMap((error) =>
-          Object.values(error.constraints ?? {}),
-        );
+        const messages = flattenValidationErrors(errors);
         return new UnprocessableEntityException(messages);
       },
       transformOptions: {


### PR DESCRIPTION
## Summary
- 로드맵 수정 콜백에서 `diff_keys`가 없어도 422가 나지 않도록 DTO 검증을 완화했습니다.
- 중첩된 validation 실패를 경로 포함 메시지로 평탄화해서 운영 로그에서 실제 오류 필드를 바로 확인할 수 있게 했습니다.
- 콜백 DTO 검증 회귀 테스트를 추가했습니다.

## Testing
- `npx jest src/domain/itinerary/presentation/dto/request/ItineraryModificationCallbackRequest.spec.ts --runInBand`
- `npx eslint src/main.ts src/global/validation/flattenValidationErrors.ts src/domain/itinerary/presentation/dto/request/ItineraryModificationCallbackRequest.ts src/domain/itinerary/presentation/dto/request/ItineraryModificationCallbackRequest.spec.ts`
- `npm run build`

Closes #200


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Tests**
  * 일정 수정 콜백 요청에 대한 검증 테스트 추가

* **Refactor**
  * 유효성 검사 오류 처리 로직 최적화로 더 명확한 오류 메시지 제공
  * 일정 수정 상태별 검증 규칙 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->