### PR TITLE
feat (#264) : 로드맵 수정 채팅 내역 조회 API 추가

### DIFF
--- a/src/domain/itinerary/presentation/ItineraryController.ts
+++ b/src/domain/itinerary/presentation/ItineraryController.ts
@@ -36,6 +36,7 @@ import { ItineraryJobStatusResponse } from './dto/response/ItineraryJobStatusRes
 import { ItineraryResultResponse } from './dto/response/ItineraryResultResponse';
 import { ChatWithItineraryResponse } from './dto/response/ChatWithItineraryResponse';
 import { ItineraryModificationJobStatusResponse } from './dto/response/ItineraryModificationJobStatusResponse';
+import { ItineraryChatHistoryResponse } from './dto/response/ItineraryChatHistoryResponse';
 
 @ApiTags('itineraries')
 @Controller('v1/itineraries')
@@ -91,10 +92,7 @@ export class ItineraryController {
   @ApiParam({ name: 'jobId', description: '작업 ID' })
   @ApiResponse({ status: 200, type: ItineraryJobStatusResponse })
   @UserApiBearerAuth()
-  async getStatus(
-    @UserId() userId: string,
-    @UuidParam('jobId') jobId: string,
-  ) {
+  async getStatus(@UserId() userId: string, @UuidParam('jobId') jobId: string) {
     const result = await this.itineraryService.getJobStatus(userId, jobId);
     return { status: result };
   }
@@ -107,12 +105,27 @@ export class ItineraryController {
   @ApiParam({ name: 'jobId', description: '작업 ID' })
   @ApiResponse({ status: 200, type: ItineraryResultResponse })
   @UserApiBearerAuth()
-  async getResult(
-    @UserId() userId: string,
-    @UuidParam('jobId') jobId: string,
-  ) {
+  async getResult(@UserId() userId: string, @UuidParam('jobId') jobId: string) {
     const result = await this.itineraryService.getJobResult(userId, jobId);
     return { result };
+  }
+
+  /**
+   * 로드맵 수정 채팅 내역 조회
+   */
+  @Get(':id/chats')
+  @ApiOperation({ summary: '로드맵 수정 채팅 내역 조회' })
+  @ApiParam({ name: 'id', description: '로드맵 ID' })
+  @ApiResponse({ status: 200, type: ItineraryChatHistoryResponse })
+  @UserApiBearerAuth()
+  async getChatHistory(
+    @UserId() userId: string,
+    @UuidParam() itineraryId: string,
+  ) {
+    return this.itineraryModificationService.getChatHistory(
+      userId,
+      itineraryId,
+    );
   }
 
   /**

--- a/src/domain/itinerary/presentation/dto/response/ItineraryChatHistoryResponse.ts
+++ b/src/domain/itinerary/presentation/dto/response/ItineraryChatHistoryResponse.ts
@@ -1,0 +1,42 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { CourseAiChat } from '../../../../course/entity/CourseAiChat.entity';
+import { ChatRole } from '../../../../course/entity/ChatRole.enum';
+
+export class ItineraryChatHistoryItemResponse {
+  @ApiProperty({ description: '채팅 메시지 ID' })
+  id: string;
+
+  @ApiProperty({ description: '메시지 발신자', enum: ChatRole })
+  role: ChatRole;
+
+  @ApiProperty({ description: '메시지 내용' })
+  content: string;
+
+  @ApiProperty({ description: '메시지 생성 시각' })
+  createdAt: Date;
+
+  static from(chat: CourseAiChat): ItineraryChatHistoryItemResponse {
+    const response = new ItineraryChatHistoryItemResponse();
+    response.id = chat.id;
+    response.role = chat.role;
+    response.content = chat.content;
+    response.createdAt = chat.createdAt;
+    return response;
+  }
+}
+
+export class ItineraryChatHistoryResponse {
+  @ApiProperty({
+    description: '로드맵 수정 채팅 내역',
+    type: [ItineraryChatHistoryItemResponse],
+  })
+  chats: ItineraryChatHistoryItemResponse[];
+
+  static from(
+    chats: ItineraryChatHistoryItemResponse[],
+  ): ItineraryChatHistoryResponse {
+    const response = new ItineraryChatHistoryResponse();
+    response.chats = chats;
+    return response;
+  }
+}

--- a/src/domain/itinerary/service/ItineraryModificationService.spec.ts
+++ b/src/domain/itinerary/service/ItineraryModificationService.spec.ts
@@ -1,23 +1,89 @@
 import { ItineraryModificationService } from './ItineraryModificationService';
 import { CompletedItineraryEditLockedException } from '../exception/CompletedItineraryEditLockedException';
+import { ChatRole } from '../../course/entity/ChatRole.enum';
+import { ItineraryJobRepository } from '../persistence/ItineraryJobRepository';
+import { TravelCourse } from '../../course/entity/TravelCourse.entity';
+import { CourseAiChat } from '../../course/entity/CourseAiChat.entity';
+import { Queue } from 'bullmq';
+
+const createService = ({
+  travelCourseRepository,
+  chatRepository,
+}: {
+  travelCourseRepository: Partial<Record<'findOne', jest.Mock>>;
+  chatRepository?: Partial<Record<'find', jest.Mock>>;
+}) =>
+  new ItineraryModificationService(
+    {} as unknown as ItineraryJobRepository,
+    travelCourseRepository as unknown as typeof travelCourseRepository &
+      import('typeorm').Repository<TravelCourse>,
+    (chatRepository ?? {}) as unknown as typeof chatRepository &
+      import('typeorm').Repository<CourseAiChat>,
+    {} as unknown as Queue,
+  );
 
 describe('ItineraryModificationService', () => {
   it('blocks chat modification requests for completed roadmaps', async () => {
-    const service = new ItineraryModificationService(
-      {} as any,
-      {
+    const service = createService({
+      travelCourseRepository: {
         findOne: jest.fn().mockResolvedValue({
           id: 'course-id',
           isCompleted: true,
           user: { id: 'user-id' },
           canModify: () => true,
         }),
-      } as any,
-      {} as any,
-    );
+      },
+    });
 
     await expect(
       service.chatWithItinerary('user-id', 'course-id', '수정해줘'),
     ).rejects.toBeInstanceOf(CompletedItineraryEditLockedException);
+  });
+
+  it('returns chat history for the owned roadmap ordered by creation time', async () => {
+    const createdAt = new Date('2026-04-14T10:00:00.000Z');
+    const service = createService({
+      travelCourseRepository: {
+        findOne: jest.fn().mockResolvedValue({
+          id: 'course-id',
+          user: { id: 'user-id' },
+        }),
+      },
+      chatRepository: {
+        find: jest.fn().mockResolvedValue([
+          {
+            id: 'chat-1',
+            role: ChatRole.USER,
+            content: '여기 바꿔줘',
+            createdAt,
+          },
+          {
+            id: 'chat-2',
+            role: ChatRole.AI,
+            content: '이렇게 수정할게요',
+            createdAt: new Date('2026-04-14T10:00:05.000Z'),
+          },
+        ]),
+      },
+    });
+
+    await expect(
+      service.getChatHistory('user-id', 'course-id'),
+    ).resolves.toEqual({
+      chats: [
+        {
+          id: 'chat-1',
+          role: ChatRole.USER,
+          content: '여기 바꿔줘',
+          createdAt,
+        },
+        {
+          id: 'chat-2',
+          role: ChatRole.AI,
+          content: '이렇게 수정할게요',
+          createdAt: new Date('2026-04-14T10:00:05.000Z'),
+        },
+      ],
+    });
   });
 });

--- a/src/domain/itinerary/service/ItineraryModificationService.ts
+++ b/src/domain/itinerary/service/ItineraryModificationService.ts
@@ -6,7 +6,12 @@ import { Queue } from 'bullmq';
 import { ItineraryJobRepository } from '../persistence/ItineraryJobRepository';
 import { ItineraryJob } from '../entity/ItineraryJob.entity';
 import { TravelCourse } from '../../course/entity/TravelCourse.entity';
+import { CourseAiChat } from '../../course/entity/CourseAiChat.entity';
 import { ChatWithItineraryResponse } from '../presentation/dto/response/ChatWithItineraryResponse';
+import {
+  ItineraryChatHistoryItemResponse,
+  ItineraryChatHistoryResponse,
+} from '../presentation/dto/response/ItineraryChatHistoryResponse';
 import { ItineraryModificationJobStatusResponse } from '../presentation/dto/response/ItineraryModificationJobStatusResponse';
 import { ItineraryNotFoundException } from '../exception/ItineraryNotFoundException';
 import { UnauthorizedItineraryAccessException } from '../exception/UnauthorizedItineraryAccessException';
@@ -30,6 +35,8 @@ export class ItineraryModificationService {
     private readonly itineraryJobRepository: ItineraryJobRepository,
     @InjectRepository(TravelCourse)
     private readonly travelCourseRepository: Repository<TravelCourse>,
+    @InjectRepository(CourseAiChat)
+    private readonly chatRepository: Repository<CourseAiChat>,
     @InjectQueue('itinerary-modification')
     private readonly modificationQueue: Queue,
   ) {}
@@ -46,20 +53,7 @@ export class ItineraryModificationService {
     itineraryId: string,
     message: string,
   ): Promise<ChatWithItineraryResponse> {
-    // 1. TravelCourse 존재 확인
-    const course = await this.travelCourseRepository.findOne({
-      where: { id: itineraryId },
-      relations: ['user'],
-    });
-
-    if (!course) {
-      throw new ItineraryNotFoundException();
-    }
-
-    // 2. 권한 확인 (본인의 로드맵인지 확인)
-    if (course.user.id !== userId) {
-      throw new UnauthorizedItineraryAccessException();
-    }
+    const course = await this.findOwnedCourse(userId, itineraryId);
 
     // 3. 완료된 로드맵 수정 잠금
     if (course.isCompleted) {
@@ -125,6 +119,25 @@ export class ItineraryModificationService {
   }
 
   /**
+   * 로드맵 수정 채팅 내역 조회
+   */
+  async getChatHistory(
+    userId: string,
+    itineraryId: string,
+  ): Promise<ItineraryChatHistoryResponse> {
+    await this.findOwnedCourse(userId, itineraryId);
+
+    const chats = await this.chatRepository.find({
+      where: { travelCourse: { id: itineraryId } },
+      order: { createdAt: 'ASC' },
+    });
+
+    return ItineraryChatHistoryResponse.from(
+      chats.map((chat) => ItineraryChatHistoryItemResponse.from(chat)),
+    );
+  }
+
+  /**
    * 수정 작업 상태 조회
    */
   async getModificationJobStatus(
@@ -141,5 +154,25 @@ export class ItineraryModificationService {
     }
 
     return ItineraryModificationJobStatusResponse.from(job);
+  }
+
+  private async findOwnedCourse(
+    userId: string,
+    itineraryId: string,
+  ): Promise<TravelCourse> {
+    const course = await this.travelCourseRepository.findOne({
+      where: { id: itineraryId },
+      relations: ['user'],
+    });
+
+    if (!course) {
+      throw new ItineraryNotFoundException();
+    }
+
+    if (course.user.id !== userId) {
+      throw new UnauthorizedItineraryAccessException();
+    }
+
+    return course;
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
- 여행 계획 수정 시 채팅 기록을 조회할 수 있는 기능 추가
- 채팅 기록을 생성 시간순으로 정렬하여 확인 가능

<!-- end of auto-generated comment: release notes by coderabbit.ai -->