### PR TITLE
fix: stabilize prod nginx api upstream target

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -6,10 +6,11 @@ services:
     depends_on:
       - app
     ports:
-      - "80:80"
+      - '80:80'
     environment:
       API_SERVER_NAME: ${API_SERVER_NAME:-api.example.com}
       AI_SERVER_NAME: ${AI_SERVER_NAME:-ai.example.com}
+      API_UPSTREAM_HOST: ${API_UPSTREAM_HOST:-mohaeng-server-core}
     volumes:
       - ./infra/nginx/default.conf.template:/etc/nginx/templates/default.conf.template:ro
     networks:
@@ -18,7 +19,7 @@ services:
       - /bin/sh
       - -c
       - |
-        envsubst '$$API_SERVER_NAME $$AI_SERVER_NAME' \
+        envsubst '$$API_SERVER_NAME $$AI_SERVER_NAME $$API_UPSTREAM_HOST' \
         < /etc/nginx/templates/default.conf.template \
         > /etc/nginx/conf.d/default.conf && \
         nginx -g 'daemon off;'
@@ -35,7 +36,7 @@ services:
     env_file:
       - .env
     expose:
-      - "8080"
+      - '8080'
     networks:
       - mohaeng-network
 
@@ -52,7 +53,7 @@ services:
     networks:
       - mohaeng-network
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${DB_USERNAME} -d ${DB_DATABASE}"]
+      test: ['CMD-SHELL', 'pg_isready -U ${DB_USERNAME} -d ${DB_DATABASE}']
       interval: 10s
       timeout: 5s
       retries: 10
@@ -61,13 +62,13 @@ services:
     image: redis:7-alpine
     container_name: mohaeng-redis
     restart: unless-stopped
-    command: ["redis-server", "--appendonly", "yes"]
+    command: ['redis-server', '--appendonly', 'yes']
     volumes:
       - redis_data:/data
     networks:
       - mohaeng-network
     healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
+      test: ['CMD', 'redis-cli', 'ping']
       interval: 10s
       timeout: 5s
       retries: 10

--- a/docs/DEPLOY_PROD_GITHUB_ACTIONS.md
+++ b/docs/DEPLOY_PROD_GITHUB_ACTIONS.md
@@ -1,12 +1,14 @@
 # Prod Deploy Runbook (Docker Hub + GitHub Actions + EC2)
 
 ## 0) 현재 배포 구조
+
 1. GitHub Actions가 Docker 이미지를 빌드
 2. Docker Hub(`docker.io`)에 이미지를 push
 3. EC2가 해당 이미지를 pull
 4. `docker compose up -d`로 컨테이너 교체
 
 ## 1) EC2 1회 세팅
+
 ```bash
 sudo apt-get update
 sudo apt-get install -y ca-certificates curl gnupg
@@ -30,21 +32,26 @@ sudo chown -R deploy:deploy /var/www/mohaeng-server-core
 ```
 
 `deploy`로 재로그인 후 확인:
+
 ```bash
 docker --version
 docker compose version
 ```
 
 ## 2) 서버 환경 파일 준비
+
 EC2에 생성:
+
 ```bash
 nano /var/www/mohaeng-server-core/.env
 ```
 
 ## 3) GitHub Secrets
+
 Repository -> Settings -> Secrets and variables -> Actions
 
 필수:
+
 - `EC2_HOST`
 - `EC2_USER` (`ubuntu` 또는 `deploy`)
 - `EC2_PORT` (`22`)
@@ -54,19 +61,26 @@ Repository -> Settings -> Secrets and variables -> Actions
 - `DOCKERHUB_TOKEN` (Docker Hub access token or password)
 
 선택:
+
 - `HEALTHCHECK_URL` (예: `http://127.0.0.1:8080/api/health`)
 - `DOCKERHUB_IMAGE` (예: `dongguli08/mohaeng`)
+- `API_UPSTREAM_HOST` (기본값: `mohaeng-server-core`)
 
 ## 4) Docker Hub 토큰
+
 private repository면 EC2에서 pull 하려면 로그인 필요합니다.
+
 - 권장: Docker Hub Access Token 발급 후 `DOCKERHUB_TOKEN`으로 사용
 
 ## 5) 배포 실행
+
 - `main` push 또는 Actions에서 `Deploy Prod` 수동 실행
 - 성공 시 EC2에서 최신 이미지로 교체됨
 
 ## 6) 운영 확인
+
 EC2에서:
+
 ```bash
 cd /var/www/mohaeng-server-core
 docker compose --env-file .deploy.env -f docker-compose.prod.yml ps
@@ -74,5 +88,6 @@ docker compose --env-file .deploy.env -f docker-compose.prod.yml logs -n 100
 ```
 
 ## 7) 참고
+
 - 현재 컨테이너 시작 명령은 `npm run start:prod`입니다.
 - 이 스크립트는 마이그레이션을 포함하므로, 앱 시작 시 migration이 실행됩니다.

--- a/infra/nginx/default.conf.template
+++ b/infra/nginx/default.conf.template
@@ -1,5 +1,5 @@
 upstream api_upstream {
-    server app:8080;
+    server ${API_UPSTREAM_HOST}:8080;
 }
 
 upstream ai_upstream {


### PR DESCRIPTION
## 작업 내용
- 운영 nginx upstream이 `app:8080`을 바라보던 설정을 제거했습니다.
- nginx 템플릿이 `API_UPSTREAM_HOST` 환경변수를 사용하도록 수정했습니다.
- 기본 upstream host를 실제 운영 API 컨테이너명인 `mohaeng-server-core`로 맞췄습니다.
- 배포 문서에 `API_UPSTREAM_HOST` 항목을 추가했습니다.

## 원인
- 운영 EC2의 nginx 컨테이너 설정은 `app:8080`으로 프록시하고 있었지만,
  실제 Nest 컨테이너 이름은 `mohaeng-server-core`였습니다.
- 이 mismatch 때문에 `api.mohaeng.kr` 요청이 nginx upstream resolution 실패로 502를 반환했습니다.

## 검증
- EC2에서 nginx 컨테이너 설정/업스트림 확인
- `curl -i http://127.0.0.1/api-docs -H "Host: api.mohaeng.kr"`
- `docker compose -f docker-compose.prod.yml config`

## 참고
- 로컬 작업트리의 `.gitignore`, `src/domain/user/UserModule.ts` 변경은 이번 PR에 포함하지 않았습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * API 업스트림 호스트를 환경 변수로 설정 가능하도록 변경하여 배포 설정의 유연성 향상

* **문서**
  * GitHub Actions 배포 설명서에 새로운 API 업스트림 호스트 설정 가이드 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->