### PR TITLE
fix: migration timestamp 충돌 및 테이블명 오류 수정

### DIFF
--- a/src/database/migrations/postgres/1772950000000-AddPlaceCategoryToPlaceTablePostgres.ts
+++ b/src/database/migrations/postgres/1772950000000-AddPlaceCategoryToPlaceTablePostgres.ts
@@ -1,16 +1,16 @@
 import { MigrationInterface, QueryRunner } from 'typeorm';
 
-export class AddPlaceCategoryToPlaceTablePostgres1772900000000 implements MigrationInterface {
+export class AddPlaceCategoryToPlaceTablePostgres1772950000000 implements MigrationInterface {
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(`
-      ALTER TABLE "place_table"
+      ALTER TABLE "place"
       ADD COLUMN IF NOT EXISTS "place_category" varchar(32) NOT NULL DEFAULT 'OTHER'
     `);
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(`
-      ALTER TABLE "place_table"
+      ALTER TABLE "place"
       DROP COLUMN IF EXISTS "place_category"
     `);
   }


### PR DESCRIPTION
## Summary
- `1772900000000-AddPlaceCategoryToPlaceTablePostgres` timestamp가 `AddIsCompletedToTravelCoursePostgres`와 충돌
- timestamp `1772900000000` → `1772950000000` 으로 변경
- 테이블명 `place_table` → `place` 로 수정 (실제 DB 테이블명 기준)

## Test plan
- [ ] 서버 재시작 후 마이그레이션 정상 실행 확인
- [ ] `place` 테이블에 `place_category` 컬럼 추가 확인
- [ ] 80포트 502 해소 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 데이터베이스 스키마 일관성 문제를 해결했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->