### PR TITLE
chore: 여행지 추천 AI 콜백 규약 정렬

### DIFF
--- a/src/domain/country/persistence/RegionRepository.ts
+++ b/src/domain/country/persistence/RegionRepository.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Region } from '../entity/Region.entity';
+import { RegionCode } from '../entity/RegionCode.enum';
 
 /**
  * Region Repository
@@ -24,6 +25,12 @@ export class RegionRepository {
 
   async findByName(name: string): Promise<Region | null> {
     return this.repository.findOne({ where: { name } });
+  }
+
+  async findByCode(regionCode: string): Promise<Region | null> {
+    return this.repository.findOne({
+      where: { regionCode: regionCode as RegionCode },
+    });
   }
 
   async findByCountryId(countryId: string): Promise<Region[]> {

--- a/src/domain/preference/processor/PreferenceProcessor.spec.ts
+++ b/src/domain/preference/processor/PreferenceProcessor.spec.ts
@@ -1,0 +1,130 @@
+import { HttpService } from '@nestjs/axios';
+import { ConfigService } from '@nestjs/config';
+import { Repository } from 'typeorm';
+import { PreferenceProcessor } from './PreferenceProcessor';
+import { PreferenceJobRepository } from '../persistence/PreferenceJobRepository';
+import { UserPreference } from '../entity/UserPreference.entity';
+import { WeatherPreference } from '../entity/WeatherPreference.enum';
+import { TravelRange } from '../entity/TravelRange.enum';
+import { TravelStyle } from '../entity/TravelStyle.enum';
+import { BudgetLevel } from '../entity/BudgetLevel.enum';
+import { FoodPersonality } from '../entity/FoodPersonality.enum';
+import { MainInterest } from '../entity/MainInterest.enum';
+
+type RecommendPayload = {
+  job_id: string;
+  weather: WeatherPreference;
+  travel_range: TravelRange;
+  travel_style: TravelStyle;
+  budget_level: BudgetLevel;
+  food_personality: FoodPersonality[];
+  main_interests: MainInterest[];
+};
+
+describe('PreferenceProcessor', () => {
+  it('builds Python payload in the AI contract shape', () => {
+    const processor = new PreferenceProcessor(
+      new ConfigService<Record<string, unknown>>({}),
+      new HttpService(),
+      {} as PreferenceJobRepository,
+      {} as Repository<UserPreference>,
+    );
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const buildPythonPayload = (
+      processor as unknown as {
+        buildPythonPayload: (
+          jobId: string,
+          preference: UserPreference,
+        ) => RecommendPayload;
+      }
+    ).buildPythonPayload.bind(processor);
+
+    const preference = new UserPreference();
+    preference.weatherPreferences = [
+      {
+        weather: WeatherPreference.OCEAN_BEACH,
+      } as UserPreference['weatherPreferences'][number],
+    ];
+    preference.travelRanges = [
+      {
+        travelRange: TravelRange.MEDIUM_HAUL,
+      } as UserPreference['travelRanges'][number],
+    ];
+    preference.travelStyles = [
+      {
+        travelStyle: TravelStyle.MODERN_TRENDY,
+      } as UserPreference['travelStyles'][number],
+    ];
+    preference.budgets = [
+      {
+        budgetLevel: BudgetLevel.BALANCED,
+      } as UserPreference['budgets'][number],
+    ];
+    preference.foodPersonalities = [
+      {
+        foodPersonality: FoodPersonality.LOCAL_HIDDEN_GEM,
+      } as UserPreference['foodPersonalities'][number],
+    ];
+    preference.mainInterests = [
+      {
+        mainInterest: MainInterest.SHOPPING_TOUR,
+      } as UserPreference['mainInterests'][number],
+    ];
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
+    const payload = buildPythonPayload('job-id', preference);
+
+    expect(payload).toEqual({
+      job_id: 'job-id',
+      weather: WeatherPreference.OCEAN_BEACH,
+      travel_range: TravelRange.MEDIUM_HAUL,
+      travel_style: TravelStyle.MODERN_TRENDY,
+      budget_level: BudgetLevel.BALANCED,
+      food_personality: [FoodPersonality.LOCAL_HIDDEN_GEM],
+      main_interests: [MainInterest.SHOPPING_TOUR],
+    });
+  });
+
+  it('builds callback url as the Nest callback base path for AI server', () => {
+    const processor = new PreferenceProcessor(
+      new ConfigService<Record<string, unknown>>({
+        CALLBACK_BASE_URL: 'https://api.mohaeng.kr',
+      }),
+      new HttpService(),
+      {} as PreferenceJobRepository,
+      {} as Repository<UserPreference>,
+    );
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const buildCallbackUrl = (
+      processor as unknown as {
+        buildCallbackUrl: () => string;
+      }
+    ).buildCallbackUrl.bind(processor);
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+    expect(buildCallbackUrl()).toBe('https://api.mohaeng.kr/api/v1');
+  });
+
+  it('preserves callback urls that already include /api/v1', () => {
+    const processor = new PreferenceProcessor(
+      new ConfigService<Record<string, unknown>>({
+        CALLBACK_BASE_URL: 'https://api.mohaeng.kr/api/v1/',
+      }),
+      new HttpService(),
+      {} as PreferenceJobRepository,
+      {} as Repository<UserPreference>,
+    );
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const buildCallbackUrl = (
+      processor as unknown as {
+        buildCallbackUrl: () => string;
+      }
+    ).buildCallbackUrl.bind(processor);
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+    expect(buildCallbackUrl()).toBe('https://api.mohaeng.kr/api/v1');
+  });
+});

--- a/src/domain/preference/processor/PreferenceProcessor.ts
+++ b/src/domain/preference/processor/PreferenceProcessor.ts
@@ -77,10 +77,7 @@ export class PreferenceProcessor extends WorkerHost {
     const payload = this.buildPythonPayload(jobId, preference);
     const pythonBaseUrl = this.configService.get<string>('PYTHON_LLM_BASE_URL');
     const serviceSecret = this.configService.get<string>('SERVICE_SECRET');
-    const callbackBaseUrl =
-      this.configService.get<string>('CALLBACK_BASE_URL') ||
-      `http://localhost:${this.configService.get<string>('PORT') || '8080'}`;
-    const callbackUrl = `${callbackBaseUrl}/api/v1/preferences/jobs/${jobId}/result`;
+    const callbackUrl = this.buildCallbackUrl();
 
     // 4. Python LLM 서버 호출 (POST /api/v1/recommend)
     try {
@@ -103,9 +100,10 @@ export class PreferenceProcessor extends WorkerHost {
       this.logger.log(
         `Python 서버 응답: status=${response.status}, jobId=${jobId}`,
       );
-    } catch (error) {
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error);
       this.logger.error(
-        `Python 서버 호출 실패: jobId=${jobId}, error=${error.message}`,
+        `Python 서버 호출 실패: jobId=${jobId}, error=${message}`,
       );
       throw error; // BullMQ 자동 재시도
     }
@@ -132,5 +130,26 @@ export class PreferenceProcessor extends WorkerHost {
       main_interests:
         preference.mainInterests?.map((i) => i.mainInterest) ?? [],
     };
+  }
+
+  /**
+   * AI 서버가 `/preferences/jobs/{job_id}/result`를 뒤에 붙일 수 있도록
+   * Nest 콜백 베이스 URL을 `/api/v1`까지만 전달한다.
+   */
+  private buildCallbackUrl(): string {
+    const configuredBaseUrl =
+      this.configService.get<string>('CALLBACK_BASE_URL') ||
+      `http://localhost:${this.configService.get<string>('PORT') || '8080'}`;
+    const normalizedBaseUrl = configuredBaseUrl.replace(/\/+$/, '');
+
+    if (normalizedBaseUrl.endsWith('/api/v1')) {
+      return normalizedBaseUrl;
+    }
+
+    if (normalizedBaseUrl.endsWith('/api')) {
+      return `${normalizedBaseUrl}/v1`;
+    }
+
+    return `${normalizedBaseUrl}/api/v1`;
   }
 }

--- a/src/domain/preference/service/PreferenceCallbackService.spec.ts
+++ b/src/domain/preference/service/PreferenceCallbackService.spec.ts
@@ -29,6 +29,7 @@ describe('PreferenceCallbackService', () => {
       ...recommendationRepository,
     };
     const mergedRegionRepository = {
+      findByCode: jest.fn(),
       findByName: jest.fn(),
       ...regionRepository,
     };
@@ -43,6 +44,10 @@ describe('PreferenceCallbackService', () => {
       service,
       preferenceJobRepository: mergedPreferenceJobRepository,
       recommendationRepository: mergedRecommendationRepository,
+      regionRepository: mergedRegionRepository as {
+        findByCode: jest.Mock;
+        findByName: jest.Mock;
+      },
     };
   };
 
@@ -117,5 +122,46 @@ describe('PreferenceCallbackService', () => {
       order: { createdAt: 'ASC' },
     });
     expect(result).toBe(recommendations);
+  });
+
+  it('maps AI region enum codes to DB regions before saving recommendations', async () => {
+    const savedJob = {
+      id: 'job-id',
+      markSuccess: jest.fn(),
+    };
+    const {
+      service,
+      preferenceJobRepository,
+      recommendationRepository,
+      regionRepository,
+    } = createService({
+      preferenceJobRepository: {
+        findById: jest.fn().mockResolvedValue(savedJob),
+        save: jest.fn(),
+      },
+      recommendationRepository: {
+        save: jest.fn(),
+      },
+      regionRepository: {
+        findByCode: jest.fn().mockResolvedValue({ id: 'region-id' }),
+        findByName: jest.fn(),
+      },
+    });
+
+    await service.handleSuccess('job-id', {
+      recommended_destinations: [{ region_name: 'MALDIVES' }],
+    });
+
+    expect(regionRepository.findByCode).toHaveBeenCalledWith('MALDIVES');
+    expect(regionRepository.findByName).not.toHaveBeenCalled();
+    expect(recommendationRepository.save).toHaveBeenCalledWith([
+      expect.objectContaining({
+        jobId: 'job-id',
+        regionName: 'MALDIVES',
+        regionId: 'region-id',
+      }),
+    ]);
+    expect(savedJob.markSuccess).toHaveBeenCalled();
+    expect(preferenceJobRepository.save).toHaveBeenCalledWith(savedJob);
   });
 });

--- a/src/domain/preference/service/PreferenceCallbackService.ts
+++ b/src/domain/preference/service/PreferenceCallbackService.ts
@@ -47,7 +47,9 @@ export class PreferenceCallbackService {
     // 추천 결과 저장 (최대 5개) - Region DB 조회 후 FK 연결
     const recommendations = await Promise.all(
       payload.recommended_destinations.slice(0, 5).map(async (dest) => {
-        const region = await this.regionRepository.findByName(dest.region_name);
+        const region =
+          (await this.regionRepository.findByCode(dest.region_name)) ??
+          (await this.regionRepository.findByName(dest.region_name));
         return PreferenceRecommendation.create(
           jobId,
           dest.region_name.slice(0, 100),


### PR DESCRIPTION
## 요약
- Mohaeng-AI 문서 규약에 맞춰 추천 요청의 callback_url을 Nest callback base path(/api/v1)로 정렬했습니다.
- 추천 결과 region_name을 AI enum 코드로 우선 해석해 region_code 기준으로 매핑하도록 변경했습니다.
- 관련 preference processor/callback 테스트를 추가 및 보강했습니다.

## 검증
- npm test -- --runInBand src/domain/preference/processor/PreferenceProcessor.spec.ts src/domain/preference/service/UserPreferenceService.spec.ts src/domain/preference/service/PreferenceCallbackService.spec.ts
- npx eslint src/domain/country/persistence/RegionRepository.ts src/domain/preference/processor/PreferenceProcessor.ts src/domain/preference/processor/PreferenceProcessor.spec.ts src/domain/preference/service/PreferenceCallbackService.ts src/domain/preference/service/PreferenceCallbackService.spec.ts

## 이슈
- closes #280

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 지역 매핑 로직이 강화되어 시스템의 안정성이 향상되었습니다.
  * 콜백 URL 처리가 최적화되었습니다.

* **테스트**
  * 선호도 처리 및 콜백 서비스에 대한 새로운 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->