### PR TITLE
chore (#283) : 여행지 추천 생성 응답을 일정 생성 플로우와 정렬

### DIFF
--- a/src/domain/preference/presentation/UserPreferenceController.spec.ts
+++ b/src/domain/preference/presentation/UserPreferenceController.spec.ts
@@ -1,0 +1,47 @@
+import { PreferenceJobStatus } from '../entity/PreferenceJob.entity';
+import { UserPreferenceController } from './UserPreferenceController';
+
+describe('UserPreferenceController', () => {
+  it('wraps recommendation job creation like itinerary generation responses', async () => {
+    const userPreferenceService = {
+      createOrUpdateAndEnqueue: jest.fn().mockResolvedValue({
+        jobId: 'job-id',
+        status: PreferenceJobStatus.PENDING,
+      }),
+    };
+
+    const controller = new UserPreferenceController(
+      userPreferenceService as any,
+      {} as any,
+      {} as any,
+    );
+
+    await expect(
+      controller.createOrUpdate('user-id', {
+        weather: 'OCEAN_BEACH',
+        travel_range: 'MEDIUM_HAUL',
+        travel_style: 'MODERN_TRENDY',
+        food_personality: ['LOCAL_HIDDEN_GEM'],
+        main_interests: ['SHOPPING_TOUR'],
+        budget_level: 'BALANCED',
+      } as any),
+    ).resolves.toEqual({
+      preference: {
+        jobId: 'job-id',
+        status: PreferenceJobStatus.PENDING,
+      },
+    });
+
+    expect(userPreferenceService.createOrUpdateAndEnqueue).toHaveBeenCalledWith(
+      {
+        userId: 'user-id',
+        weather: 'OCEAN_BEACH',
+        travelRange: 'MEDIUM_HAUL',
+        travelStyle: 'MODERN_TRENDY',
+        foodPersonalities: ['LOCAL_HIDDEN_GEM'],
+        mainInterests: ['SHOPPING_TOUR'],
+        budget: 'BALANCED',
+      },
+    );
+  });
+});

--- a/src/domain/preference/presentation/UserPreferenceController.ts
+++ b/src/domain/preference/presentation/UserPreferenceController.ts
@@ -19,6 +19,7 @@ import { PreferenceCallbackService } from '../service/PreferenceCallbackService'
 import { RegionLikeService } from '../../country/service/RegionLikeService';
 import { CreateUserPreferenceRequest } from './dto/request/CreateUserPreferenceRequest';
 import { PreferenceCallbackRequest } from './dto/request/PreferenceCallbackRequest';
+import { CreatePreferenceResponse } from './dto/response/CreatePreferenceResponse';
 import { UserPreferenceResponse } from './dto/response/UserPreferenceResponse';
 import { PreferenceRecommendationResponse } from './dto/response/PreferenceRecommendationResponse';
 
@@ -51,14 +52,14 @@ export class UserPreferenceController {
   @ApiOperation({
     summary: '선호도 등록/수정 후 여행지 추천 작업 시작 (비동기)',
   })
-  @ApiResponse({ status: 202, description: '{ jobId, status: "PENDING" }' })
+  @ApiResponse({ status: 202, type: CreatePreferenceResponse })
   @ApiResponse({ status: 400, description: '잘못된 요청' })
   @ApiResponse({ status: 401, description: '인증 실패' })
   async createOrUpdate(
     @UserId() userId: string,
     @Body() request: CreateUserPreferenceRequest,
-  ): Promise<{ jobId: string; status: string }> {
-    return this.userPreferenceService.createOrUpdateAndEnqueue({
+  ): Promise<{ preference: CreatePreferenceResponse }> {
+    const result = await this.userPreferenceService.createOrUpdateAndEnqueue({
       userId,
       weather: request.weather,
       travelRange: request.travel_range,
@@ -67,6 +68,8 @@ export class UserPreferenceController {
       mainInterests: request.main_interests,
       budget: request.budget_level,
     });
+
+    return { preference: result };
   }
 
   /**

--- a/src/domain/preference/presentation/dto/response/CreatePreferenceResponse.ts
+++ b/src/domain/preference/presentation/dto/response/CreatePreferenceResponse.ts
@@ -1,0 +1,20 @@
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  PreferenceJob,
+  PreferenceJobStatus,
+} from '../../../entity/PreferenceJob.entity';
+
+export class CreatePreferenceResponse {
+  @ApiProperty({ description: '작업 ID (polling에 사용)' })
+  jobId: string;
+
+  @ApiProperty({ description: '작업 상태', enum: PreferenceJobStatus })
+  status: PreferenceJobStatus;
+
+  static from(job: PreferenceJob): CreatePreferenceResponse {
+    const response = new CreatePreferenceResponse();
+    response.jobId = job.id;
+    response.status = job.status;
+    return response;
+  }
+}

--- a/src/domain/preference/service/UserPreferenceService.ts
+++ b/src/domain/preference/service/UserPreferenceService.ts
@@ -4,7 +4,10 @@ import { Queue } from 'bullmq';
 import { DataSource } from 'typeorm';
 import { UserPreferenceRepository } from '../persistence/UserPreferenceRepository';
 import { PreferenceJobRepository } from '../persistence/PreferenceJobRepository';
-import { PreferenceJob } from '../entity/PreferenceJob.entity';
+import {
+  PreferenceJob,
+  PreferenceJobStatus,
+} from '../entity/PreferenceJob.entity';
 import { UserPreference } from '../entity/UserPreference.entity';
 import { UserPreferenceWeather } from '../entity/UserPreferenceWeather.entity';
 import { UserPreferenceTravelRange } from '../entity/UserPreferenceTravelRange.entity';
@@ -105,7 +108,7 @@ export class UserPreferenceService {
 
   async createOrUpdateAndEnqueue(
     dto: CreateUserPreferenceDto,
-  ): Promise<{ jobId: string; status: string }> {
+  ): Promise<{ jobId: string; status: PreferenceJobStatus }> {
     const preference = await this.createOrUpdate(dto);
     const job = PreferenceJob.create(dto.userId, preference.id);
     const savedJob = await this.preferenceJobRepository.save(job);


### PR DESCRIPTION
## 작업 내용
- 여행지 추천 생성 API 응답을 일정 생성 API와 같은 wrapper 패턴으로 정렬
- 프런트가 data.preference.jobId 로 polling 시작 가능하도록 컨트롤러 응답 수정
- 관련 컨트롤러 계약 테스트 추가

## 변경 사항
- POST /api/v1/preferences 응답을 preference 아래 jobId, status를 담는 형태로 변경
- 추천 생성 응답 DTO 추가
- 서비스 반환 타입을 PreferenceJobStatus enum으로 정리

## 검증
- npm test -- --runInBand src/domain/preference/presentation/UserPreferenceController.spec.ts src/domain/preference/service/UserPreferenceService.spec.ts src/domain/preference/service/PreferenceCallbackService.spec.ts
- npx eslint src/domain/preference/presentation/UserPreferenceController.ts src/domain/preference/presentation/UserPreferenceController.spec.ts src/domain/preference/presentation/dto/response/CreatePreferenceResponse.ts src/domain/preference/service/UserPreferenceService.ts

## 이슈
- closes #283

## 리스크
- 기존 클라이언트가 POST /preferences 응답의 top-level jobId를 직접 읽고 있었다면 응답 파서 수정이 필요함

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **테스트**
  * 사용자 선호도 컨트롤러 단위 테스트 추가

* **변경사항**
  * POST /v1/preferences 엔드포인트 응답 형식 개선: 선호도 데이터 포함 응답
  * 타입 안정성 향상을 위한 상태 관리 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->